### PR TITLE
Have fixed error with wrong job id

### DIFF
--- a/pystalkd/Beanstalkd.py
+++ b/pystalkd/Beanstalkd.py
@@ -207,7 +207,7 @@ class Connection(object):
                                         ok_status=ok_status,
                                         error_status=error_status)
 
-        return int(job[0])
+        return int(job)
 
     def parse_job(self, body):
         job_id, body_rest = body.split(maxsplit=1)


### PR DESCRIPTION
b'13'[0] will return ord('1'). What we actually need is int(job_id) or int(b'13') == 13