### PR TITLE
[Fix] fix potentially infinite loop

### DIFF
--- a/pystalkd/Beanstalkd.py
+++ b/pystalkd/Beanstalkd.py
@@ -125,7 +125,8 @@ class Connection(object):
 
             mem_view = mem_view[0:n_bytes]
             byte_list.append(mem_view.tobytes())
-            if mem_view[-2:] == b'\r\n':
+            test_protocol_end = mem_view[-2:]
+            if test_protocol_end == b'\r\n' or len(test_protocol_end) < 2:
                 break
 
         return b''.join(byte_list)


### PR DESCRIPTION
So here we goes guys. If you read from socket, than there is a chance that combination of two bytes ('\r\n') will be stored in two different buffers and client will go to infinite loop.
So I write a small fix, if mem_view has less than two elements, than stop loop.

Example stack_trace:
recv_from(pd, 'a very long message\r')
recv_from(pd, '\n')
recv_from(pd, ....)
