### PR TITLE
test.py gives no warnings on Python 3.7

### DIFF
--- a/pystalkd/Beanstalkd.py
+++ b/pystalkd/Beanstalkd.py
@@ -388,7 +388,7 @@ class Connection(object):
 
         import yaml
 
-        return yaml.load(body)
+        return yaml.load(body, Loader=yaml.FullLoader)
 
     def tubes(self):
         """Return a list of all existing tubes.

--- a/test.py
+++ b/test.py
@@ -171,7 +171,7 @@ class TestBeanstalkd(unittest.TestCase):
 
         job = self.conn.reserve(0)
 
-        self.assertEquals(job.body, "台灣繁體字 Traditional Chinese characters")
+        self.assertEqual(job.body, "台灣繁體字 Traditional Chinese characters")
         job.delete()
 
     def test_bytes(self):
@@ -185,7 +185,7 @@ class TestBeanstalkd(unittest.TestCase):
         self.assertIsInstance(job_id, int, "where's my job id?!")
 
         job = self.conn.reserve_bytes(0)
-        self.assertEquals(job.body, test_bytes)
+        self.assertEqual(job.body, test_bytes)
         job.delete()
 
     def test_big(self):


### PR DESCRIPTION
This PR addresses warnings with recent versions of Python 3.7 and PyYAML 5.1.

<details>
<summary>Test output before applying this PR</summary>

```
$ python3.7 pystalkd/test.py
/home/maxwell-k/pystalkd/pystalkd/Beanstalkd.py:391: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  return yaml.load(body)
.....pystalkd/test.py:174: DeprecationWarning: Please use assertEqual instead.
  self.assertEquals(job.body, "台灣繁體字 Traditional Chinese characters")
.pystalkd/test.py:188: DeprecationWarning: Please use assertEqual instead.
  self.assertEquals(job.body, test_bytes)
....
----------------------------------------------------------------------
Ran 10 tests in 0.182s

OK
```

</details>




<details>
<summary>Test output after applying this PR</summary>

```
$ python3.7 pystalkd/test.py
..........
----------------------------------------------------------------------
Ran 10 tests in 0.176s

OK

```

</details>